### PR TITLE
Fix failing run

### DIFF
--- a/bin/modules/generateHtml.test.js
+++ b/bin/modules/generateHtml.test.js
@@ -4,13 +4,18 @@ const fs = require('fs');
 
 describe('convert txt file to html tests', () => {
   let inputFilePath = './testFile.txt';
+  const outputDir = './dist';
   const fileInput = `sample input`;
 
   beforeEach(() => {
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir);
+    }
     fs.writeFileSync(inputFilePath, fileInput);
   });
 
   afterAll(() => {
+    fs.rmdirSync(outputDir, { recursive: true });
     fs.unlinkSync(inputFilePath);
   });
 


### PR DESCRIPTION
The CI tests are currently failing due to `dist` missing in the test run. This adds the creation and deletion of the output directory.