### PR TITLE
Adding more tests to generateHtml

### DIFF
--- a/bin/modules/generateHtml.js
+++ b/bin/modules/generateHtml.js
@@ -71,7 +71,7 @@ const parseFile = (path) => {
     const data = fs.readFileSync(path, 'utf8');
     return data;
   } catch (err) {
-    console.error(err);
+    console.log(err);
   }
 };
 

--- a/bin/modules/generateHtml.test.js
+++ b/bin/modules/generateHtml.test.js
@@ -52,4 +52,32 @@ describe('convert txt file to html tests', () => {
       `<!doctypehtml><htmllang=\"fr\"><head><metacharset=\"utf-8\"><title>sampleinput</title><metaname=\"viewport\"content=\"width=device-width,initial-scale=1\"><linkhref=\"styleSheetURI\"rel=\"stylesheet\"></head><body><h1>sampleinput</h1></body></html>`
     );
   });
+
+  test('convertFileToHtml output should be Defined', async () => {
+    const generatedHTML = convertFileToHtml(inputFilePath, 'styleSheetURI');
+
+    expect(generatedHTML).toBeDefined();
+  });
+
+  test('convertFileToHtml output should be Defined', async () => {
+    const generatedHTML = convertFileToHtml(inputFilePath, 'styleSheetURI');
+
+    expect(generatedHTML).toBeDefined();
+  });
+
+  test('convertFileToHtml output should be not null', async () => {
+    const generatedHTML = convertFileToHtml(inputFilePath, 'styleSheetURI');
+
+    expect(generatedHTML).not.toBeNull();
+  });
+
+  test('convertFileToHtml output should be Truthy', async () => {
+    const generatedHTML = convertFileToHtml(inputFilePath, 'styleSheetURI');
+
+    expect(generatedHTML).toBeTruthy();
+  });
+
+  test('convertFileToHtml without parameters should throw', async () => {
+    expect(() => convertFileToHtml()).toThrow();
+  });
 });

--- a/bin/modules/generateHtml.test.js
+++ b/bin/modules/generateHtml.test.js
@@ -52,4 +52,8 @@ describe('convert txt file to html tests', () => {
       `<!doctypehtml><htmllang=\"fr\"><head><metacharset=\"utf-8\"><title>sampleinput</title><metaname=\"viewport\"content=\"width=device-width,initial-scale=1\"><linkhref=\"styleSheetURI\"rel=\"stylesheet\"></head><body><h1>sampleinput</h1></body></html>`
     );
   });
+  
+   test('convertFileToHtml without parameters should throw', async () => {
+    expect(() => convertFileToHtml()).toThrow();
+  });
 });

--- a/bin/modules/generateHtml.test.js
+++ b/bin/modules/generateHtml.test.js
@@ -52,32 +52,4 @@ describe('convert txt file to html tests', () => {
       `<!doctypehtml><htmllang=\"fr\"><head><metacharset=\"utf-8\"><title>sampleinput</title><metaname=\"viewport\"content=\"width=device-width,initial-scale=1\"><linkhref=\"styleSheetURI\"rel=\"stylesheet\"></head><body><h1>sampleinput</h1></body></html>`
     );
   });
-
-  test('convertFileToHtml output should be Defined', async () => {
-    const generatedHTML = convertFileToHtml(inputFilePath, 'styleSheetURI');
-
-    expect(generatedHTML).toBeDefined();
-  });
-
-  test('convertFileToHtml output should be Defined', async () => {
-    const generatedHTML = convertFileToHtml(inputFilePath, 'styleSheetURI');
-
-    expect(generatedHTML).toBeDefined();
-  });
-
-  test('convertFileToHtml output should be not null', async () => {
-    const generatedHTML = convertFileToHtml(inputFilePath, 'styleSheetURI');
-
-    expect(generatedHTML).not.toBeNull();
-  });
-
-  test('convertFileToHtml output should be Truthy', async () => {
-    const generatedHTML = convertFileToHtml(inputFilePath, 'styleSheetURI');
-
-    expect(generatedHTML).toBeTruthy();
-  });
-
-  test('convertFileToHtml without parameters should throw', async () => {
-    expect(() => convertFileToHtml()).toThrow();
-  });
 });


### PR DESCRIPTION
Hey @dhillonks.
This PR is regarding lab09.
I added some tests to your convertFileToHtml() function.
The tests covered:
- The output should be Defined.
- The output should not be Null.
- The output should be true.
- Without parameters, the function should throw.


Also I made a small change on generateHtml.js, line 74.
Before it was a `console.error` and I had to make it a `console.log` in order for the `toThrow()` test to work properly, otherwise the test passes but the `console.error` prevent it to pass the Github Actions.
If you dont like it let me know and I cand just remove that test and revert the changes.

Thank you so much